### PR TITLE
Support for choosing a subset of the default plugins

### DIFF
--- a/src/js/angular-debug-bar.js
+++ b/src/js/angular-debug-bar.js
@@ -135,8 +135,9 @@
             }
         });
 
-        this.clearDefaultPlugins = function () {
-            PLUGINS = {};
+        this.clearDefaultPlugins = function (keepPlugins) {
+            keepPlugins = keepPlugins || [];
+            PLUGINS = _pick(PLUGINS, keepPlugins);
         };
 
         this.setRefreshInterval = function (interval) {


### PR DESCRIPTION
Extended `clearDefaultPlugins` to support  retaining specified plugins.

* Existing implementation of clearing all default plugins is retained if no parameter is specified
* Those wishing to retain a subset of the plugins can pass an array of plugin names to the clearDefaultPlugins method

e.g.  `debugBarProvider.clearDefaultPlugins(['watchCount', 'loadTime', 'listenerCount', 'latency']);`

